### PR TITLE
Builds in VS2017 (and 19) now and updates the output to support VS2019

### DIFF
--- a/AnotherAttachToAny/AnotherAttachToAny.csproj
+++ b/AnotherAttachToAny/AnotherAttachToAny.csproj
@@ -65,9 +65,19 @@
     <RunCodeAnalysis>true</RunCodeAnalysis>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="EnvDTE, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+    </Reference>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Microsoft.VisualStudio.OLE.Interop" />
-    <Reference Include="Microsoft.VisualStudio.Shell.Framework, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+    <Reference Include="Microsoft.VisualStudio.CoreUtility, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.VisualStudio.CoreUtility.15.6.27740\lib\net46\Microsoft.VisualStudio.CoreUtility.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.OLE.Interop, Version=7.1.40304.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <HintPath>..\packages\Microsoft.VisualStudio.OLE.Interop.7.10.6071\lib\Microsoft.VisualStudio.OLE.Interop.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Shell.Framework, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.VisualStudio.Shell.Framework.15.9.28307\lib\net45\Microsoft.VisualStudio.Shell.Framework.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.VisualStudio.Shell.Interop" />
     <Reference Include="Microsoft.VisualStudio.Shell.Interop.8.0" />
     <Reference Include="Microsoft.VisualStudio.Shell.Interop.9.0" />
@@ -83,16 +93,33 @@
     <Reference Include="Microsoft.VisualStudio.Shell.Immutable.10.0" />
     <Reference Include="Microsoft.VisualStudio.Shell.Immutable.11.0" />
     <Reference Include="Microsoft.VisualStudio.Shell.Immutable.12.0" />
+    <Reference Include="Microsoft.VisualStudio.Threading, Version=15.6.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.VisualStudio.Threading.15.6.31\lib\net46\Microsoft.VisualStudio.Threading.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Utilities, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.VisualStudio.Utilities.15.9.28307\lib\net46\Microsoft.VisualStudio.Utilities.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Validation, Version=15.3.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.VisualStudio.Validation.15.3.15\lib\net45\Microsoft.VisualStudio.Validation.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Web.Administration, Version=7.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <Private>True</Private>
       <HintPath>..\packages\Microsoft.Web.Administration.7.0.0.0\lib\net20\Microsoft.Web.Administration.dll</HintPath>
     </Reference>
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.6.0.6\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="StreamJsonRpc, Version=1.3.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\StreamJsonRpc.1.3.23\lib\net45\StreamJsonRpc.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
+    <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
     <Reference Include="System.Design" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Management" />
+    <Reference Include="System.Net.Http" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
     <Reference Include="PresentationCore" />
@@ -101,42 +128,6 @@
     <Reference Include="System.Xaml" />
   </ItemGroup>
   <ItemGroup>
-    <COMReference Include="EnvDTE">
-      <Guid>{80CC9F66-E7D8-4DDD-85B6-D9E6CD0E93E2}</Guid>
-      <VersionMajor>8</VersionMajor>
-      <VersionMinor>0</VersionMinor>
-      <Lcid>0</Lcid>
-      <WrapperTool>primary</WrapperTool>
-      <Isolated>False</Isolated>
-      <EmbedInteropTypes>False</EmbedInteropTypes>
-    </COMReference>
-    <COMReference Include="EnvDTE100">
-      <Guid>{26AD1324-4B7C-44BC-84F8-B86AED45729F}</Guid>
-      <VersionMajor>10</VersionMajor>
-      <VersionMinor>0</VersionMinor>
-      <Lcid>0</Lcid>
-      <WrapperTool>primary</WrapperTool>
-      <Isolated>False</Isolated>
-      <EmbedInteropTypes>False</EmbedInteropTypes>
-    </COMReference>
-    <COMReference Include="EnvDTE80">
-      <Guid>{1A31287A-4D7D-413E-8E32-3B374931BD89}</Guid>
-      <VersionMajor>8</VersionMajor>
-      <VersionMinor>0</VersionMinor>
-      <Lcid>0</Lcid>
-      <WrapperTool>primary</WrapperTool>
-      <Isolated>False</Isolated>
-      <EmbedInteropTypes>False</EmbedInteropTypes>
-    </COMReference>
-    <COMReference Include="EnvDTE90">
-      <Guid>{2CE2370E-D744-4936-A090-3FFFE667B0E1}</Guid>
-      <VersionMajor>9</VersionMajor>
-      <VersionMinor>0</VersionMinor>
-      <Lcid>0</Lcid>
-      <WrapperTool>primary</WrapperTool>
-      <Isolated>False</Isolated>
-      <EmbedInteropTypes>False</EmbedInteropTypes>
-    </COMReference>
     <COMReference Include="Microsoft.VisualStudio.CommandBars">
       <Guid>{1CBA492E-7263-47BB-87FE-639000619B15}</Guid>
       <VersionMajor>8</VersionMajor>
@@ -251,6 +242,9 @@
       <ProductName>.NET Framework 3.5 SP1</ProductName>
       <Install>false</Install>
     </BootstrapperPackage>
+  </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\packages\Microsoft.VisualStudio.Threading.Analyzers.15.6.31\analyzers\cs\Microsoft.VisualStudio.Threading.Analyzers.dll" />
   </ItemGroup>
   <PropertyGroup>
     <UseCodebase>true</UseCodebase>

--- a/AnotherAttachToAny/Constants.cs
+++ b/AnotherAttachToAny/Constants.cs
@@ -2,6 +2,6 @@
 {
     public static class Constants
     {
-        public const string Version = "1.1.0.0";
+        public const string Version = "1.1.1.0";
     }
 }

--- a/AnotherAttachToAny/Resources.Designer.cs
+++ b/AnotherAttachToAny/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace ArcDev.AnotherAttachToAny {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {

--- a/AnotherAttachToAny/packages.config
+++ b/AnotherAttachToAny/packages.config
@@ -1,4 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Microsoft.VisualStudio.CoreUtility" version="15.6.27740" targetFramework="net46" />
+  <package id="Microsoft.VisualStudio.OLE.Interop" version="7.10.6071" targetFramework="net46" />
+  <package id="Microsoft.VisualStudio.Shell.Framework" version="15.9.28307" targetFramework="net46" />
+  <package id="Microsoft.VisualStudio.Threading" version="15.6.31" targetFramework="net46" />
+  <package id="Microsoft.VisualStudio.Threading.Analyzers" version="15.6.31" targetFramework="net46" />
+  <package id="Microsoft.VisualStudio.Utilities" version="15.9.28307" targetFramework="net46" />
+  <package id="Microsoft.VisualStudio.Validation" version="15.3.15" targetFramework="net46" />
   <package id="Microsoft.Web.Administration" version="7.0.0.0" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="6.0.6" targetFramework="net46" />
+  <package id="StreamJsonRpc" version="1.3.23" targetFramework="net46" />
 </packages>

--- a/AnotherAttachToAny/source.extension.vsixmanifest
+++ b/AnotherAttachToAny/source.extension.vsixmanifest
@@ -1,33 +1,33 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
-	<Metadata>
-		<Identity Id="9071916a-d034-41ea-bc44-65d10858bb02" Version="1.1.0" Language="en-US" Publisher="ArcDev" />
-		<DisplayName>AnotherAttachToAny</DisplayName>
-		<Description xml:space="preserve">Attach Visual Studio to any running process. Configure up to 20 shortcuts for attaching Visual Studio debugger to using combinations of process name, process owner/username, and appPool name (of IIS worker processes).
+    <Metadata>
+        <Identity Id="9071916a-d034-41ea-bc44-65d10858bb02" Version="1.1.1" Language="en-US" Publisher="ArcDev" />
+        <DisplayName>AnotherAttachToAny</DisplayName>
+        <Description xml:space="preserve">Attach Visual Studio to any running process. Configure up to 20 shortcuts for attaching Visual Studio debugger to using combinations of process name, process owner/username, and appPool name (of IIS worker processes).
 (Forked from Ryan Conrad's AttachToAny https://github.com/camalot/AttachToAny)
 </Description>
-		<MoreInfo>https://github.com/arcdev/AnotherAttachToAny</MoreInfo>
-		<License>LICENSE.txt</License>
-		<!--<GettingStartedGuide>http://blog.twimager.com/2014/01/published-my-first-visual-studio.html</GettingStartedGuide>-->
-		<ReleaseNotes>ReleaseNotes.txt</ReleaseNotes>
-		<!--<PreviewImage>ata-preview.png</PreviewImage>-->
-		<Tags>debug, debugger, debugging</Tags>
-	</Metadata>
-	<Installation InstalledByMsi="false">
-		<InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[11.0,15.0]" />
-		<InstallationTarget Version="[11.0,15.0]" Id="Microsoft.VisualStudio.Ultimate" />
-		<InstallationTarget Version="[11.0,15.0]" Id="Microsoft.VisualStudio.Enterprise" />
-	</Installation>
-	<Dependencies>
+        <MoreInfo>https://github.com/arcdev/AnotherAttachToAny</MoreInfo>
+        <License>LICENSE.txt</License>
+        <!--<GettingStartedGuide>http://blog.twimager.com/2014/01/published-my-first-visual-studio.html</GettingStartedGuide>-->
+        <ReleaseNotes>ReleaseNotes.txt</ReleaseNotes>
+        <!--<PreviewImage>ata-preview.png</PreviewImage>-->
+        <Tags>debug, debugger, debugging</Tags>
+    </Metadata>
+    <Installation InstalledByMsi="false">
+        <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[11.0,17.0)" />
+        <InstallationTarget Version="[11.0,17.0)" Id="Microsoft.VisualStudio.Ultimate" />
+        <InstallationTarget Version="[11.0,17.0)" Id="Microsoft.VisualStudio.Enterprise" />
+    </Installation>
+    <Dependencies>
 		<Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
-		<!--<Dependency Id="Microsoft.VisualStudio.MPF.12.0" DisplayName="Visual Studio MPF 12.0" d:Source="Installed" Version="[12.0]" />-->
-	</Dependencies>
-	<Assets>
-		<Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
-	</Assets>
-	<Prerequisites>
-		<Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
-		<!--<Prerequisite Id="Microsoft.VisualStudio.Component.DiagnosticTools" Version="[15.0.25814.0,16.0)" DisplayName="Profiling tools" />-->
-		<!--<Prerequisite Id="Microsoft.VisualStudio.Shell.12.0" Version="[12.0]" />-->
-	</Prerequisites>
+        <!--<Dependency Id="Microsoft.VisualStudio.MPF.12.0" DisplayName="Visual Studio MPF 12.0" d:Source="Installed" Version="[12.0]" />-->
+    </Dependencies>
+    <Assets>
+        <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
+    </Assets>
+    <Prerequisites>
+        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,17.0)" DisplayName="Visual Studio core editor" />
+        <!--<Prerequisite Id="Microsoft.VisualStudio.Component.DiagnosticTools" Version="[15.0.25814.0,16.0)" DisplayName="Profiling tools" />-->
+        <!--<Prerequisite Id="Microsoft.VisualStudio.Shell.12.0" Version="[12.0]" />-->
+    </Prerequisites>
 </PackageManifest>

--- a/README.md
+++ b/README.md
@@ -11,3 +11,5 @@ Uses combinations of process name, process owner/username, and/or appPool name (
 as of v1.0.9.0 - support for Visual Studio 2017 RC
 
 as of v1.1.0.0 - multi-process  handling
+
+as of v1.1.1.0 - Visual Studio 2019 support

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -1,3 +1,6 @@
+1.1.1
+	- added Visual Studio 2019 support
+
 1.1.0
 	- added Multi-process match attach handling (First, Last, All, Random, Prompt, None)
 	- removed dependency on Microsoft.VisualStudio.MPF.12.0


### PR DESCRIPTION
Hi there! I've updated the project a little to make it build again and it now outputs a VSIX that will install in VS2019 too.

Until this is merged, you can use the attached file and rename it from `.vsix.zip` to `.vsix` and install it, works exactly the same as before. 

[AnotherAttachToAny.vsix.zip](https://github.com/arcdev/AnotherAttachToAny/files/2788800/AnotherAttachToAny.vsix.zip)
